### PR TITLE
Rework common conditions and consumer count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/*.pyc
+**/*.pyo
 .idea/
 build/
 dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2
+FROM python:2-alpine
 
 LABEL maintainer="milonas.ko@gmail.com"
 

--- a/rabbitmqalert/config/config.ini.example
+++ b/rabbitmqalert/config/config.ini.example
@@ -12,6 +12,7 @@ ready_queue_size=0
 unack_queue_size=0
 total_queue_size=0
 consumers_connected=1
+queue_consumers_connected=1
 open_connections=1
 nodes_running=1
 node_memory_used=100

--- a/rabbitmqalert/optionsresolver.py
+++ b/rabbitmqalert/optionsresolver.py
@@ -120,11 +120,8 @@ class OptionsResolver:
                     queue_conditions["unack_queue_size"] = cli_arguments.unack_queue_size or config_file_options.getint(queue_conditions_section_name, "unack_queue_size")
                     queue_conditions["total_queue_size"] = cli_arguments.total_queue_size or config_file_options.getint(queue_conditions_section_name, "total_queue_size")
                     queue_conditions["consumers_connected"] = cli_arguments.consumers_connected or config_file_options.getint(queue_conditions_section_name, "consumers_connected")
-                    queue_conditions["open_connections"] = cli_arguments.open_connections or config_file_options.getint(queue_conditions_section_name, "open_connections")
-                    queue_conditions["nodes_running"] = cli_arguments.nodes_running or config_file_options.getint(queue_conditions_section_name, "nodes_running")
-                    queue_conditions["node_memory_used"] = cli_arguments.node_memory_used or config_file_options.getint(queue_conditions_section_name, "node_memory_used")
                     conditions[queue] = queue_conditions
                 except:
                     conditions[queue] = default_conditions
 
-        return {"conditions": conditions}
+        return {"conditions": conditions, "default_conditions": default_conditions}

--- a/rabbitmqalert/rabbitmqalert.py
+++ b/rabbitmqalert/rabbitmqalert.py
@@ -32,16 +32,16 @@ class RabbitMQAlert:
         consumers_connected_min = queue_conditions.get("consumers_connected")
 
         if ready_size is not None and messages_ready > ready_size:
-            self.send_notification(options, "%s: messages_ready > %s" % (queue, str(ready_size)))
+            self.send_notification(options, "%s: messages_ready = %d > %d" % (queue, messages_ready, ready_size))
 
         if unack_size is not None and messages_unacknowledged > unack_size:
-            self.send_notification(options, "%s: messages_unacknowledged > %s" % (queue, str(unack_size)))
+            self.send_notification(options, "%s: messages_unacknowledged = %d > %d" % (queue, messages_unacknowledged, unack_size))
 
         if total_size is not None and messages > total_size:
-            self.send_notification(options, "%s: messages > %s" % (queue, str(total_size)))
+            self.send_notification(options, "%s: messages = %d > %d" % (queue, messages, total_size))
 
         if consumers_connected_min is not None and consumers < consumers_connected_min:
-            self.send_notification(options, "%s: consumers_connected < %s" % (queue, str(consumers_connected_min)))
+            self.send_notification(options, "%s: consumers_connected = %d < %d" % (queue, consumers, consumers_connected_min))
 
     def check_connection_conditions(self, options):
         url = "http://%s:%s/api/connections" % (options["host"], options["port"])
@@ -54,7 +54,7 @@ class RabbitMQAlert:
         open_connections_min = options["default_conditions"].get("open_connections")
 
         if open_connections is not None and open_connections < open_connections_min:
-            self.send_notification(options, "open_connections < %s" % str(open_connections_min))
+            self.send_notification(options, "open_connections = %d < %d" % (open_connections, open_connections_min))
 
     def check_node_conditions(self, options):
         url = "http://%s:%s/api/nodes" % (options["host"], options["port"])
@@ -69,11 +69,11 @@ class RabbitMQAlert:
         node_memory = conditions.get("node_memory_used")
 
         if nodes_run is not None and nodes_running < nodes_run:
-            self.send_notification(options, "nodes_running < %s" % str(nodes_run))
+            self.send_notification(options, "nodes_running = %d < %d" % (nodes_running, nodes_run))
 
         for node in data:
             if node_memory is not None and node.get("mem_used") > (node_memory * 1000000):
-                self.send_notification(options, "Node %s - node_memory_used > %s MBs" % (node.get("name"), str(node_memory)))
+                self.send_notification(options, "Node %s - node_memory_used = %d > %d MBs" % (node.get("name"), node.get("mem_used"), node_memory))
 
     def send_request(self, url, options):
         password_mgr = urllib2.HTTPPasswordMgrWithDefaultRealm()

--- a/rabbitmqalert/rabbitmqalert.py
+++ b/rabbitmqalert/rabbitmqalert.py
@@ -64,9 +64,9 @@ class RabbitMQAlert:
 
         nodes_running = len(data)
 
-        queue_conditions = options["default_conditions"]
-        nodes_run = queue_conditions.get("nodes_running")
-        node_memory = queue_conditions.get("node_memory_used")
+        conditions = options["default_conditions"]
+        nodes_run = conditions.get("nodes_running")
+        node_memory = conditions.get("node_memory_used")
 
         if nodes_run is not None and nodes_running < nodes_run:
             self.send_notification(options, "nodes_running < %s" % str(nodes_run))

--- a/rabbitmqalert/tests/test_optionsresolver.py
+++ b/rabbitmqalert/tests/test_optionsresolver.py
@@ -67,10 +67,10 @@ class OptionsResolverTestCase(unittest.TestCase):
         self.assertEquals(20, options_result["conditions"]["foo-queue"]["ready_queue_size"])
         self.assertEquals(30, options_result["conditions"]["foo-queue"]["unack_queue_size"])
         self.assertEquals(40, options_result["conditions"]["foo-queue"]["total_queue_size"])
-        self.assertEquals(50, options_result["conditions"]["foo-queue"]["consumers_connected"])
-        self.assertEquals(51, options_result["conditions"]["foo-queue"]["open_connections"])
-        self.assertEquals(60, options_result["conditions"]["foo-queue"]["nodes_running"])
-        self.assertEquals(70, options_result["conditions"]["foo-queue"]["node_memory_used"])
+        self.assertEquals(50, options_result["default_conditions"]["consumers_connected"])
+        self.assertEquals(51, options_result["default_conditions"]["open_connections"])
+        self.assertEquals(60, options_result["default_conditions"]["nodes_running"])
+        self.assertEquals(70, options_result["default_conditions"]["node_memory_used"])
         self.assertEquals(["foo-email-to"], options_result["email_to"])
         self.assertEquals("foo-email-from", options_result["email_from"])
         self.assertEquals("foo-email-subject", options_result["email_subject"])
@@ -126,10 +126,10 @@ class OptionsResolverTestCase(unittest.TestCase):
         self.assertEquals(20, options_result["conditions"]["foo-queue"]["ready_queue_size"])
         self.assertEquals(30, options_result["conditions"]["foo-queue"]["unack_queue_size"])
         self.assertEquals(40, options_result["conditions"]["foo-queue"]["total_queue_size"])
-        self.assertEquals(50, options_result["conditions"]["foo-queue"]["consumers_connected"])
-        self.assertEquals(51, options_result["conditions"]["foo-queue"]["open_connections"])
-        self.assertEquals(60, options_result["conditions"]["foo-queue"]["nodes_running"])
-        self.assertEquals(70, options_result["conditions"]["foo-queue"]["node_memory_used"])
+        self.assertEquals(50, options_result["default_conditions"]["consumers_connected"])
+        self.assertEquals(51, options_result["default_conditions"]["open_connections"])
+        self.assertEquals(60, options_result["default_conditions"]["nodes_running"])
+        self.assertEquals(70, options_result["default_conditions"]["node_memory_used"])
         self.assertEquals(["foo-email-to"], options_result["email_to"])
         self.assertEquals("foo-email-from", options_result["email_from"])
         self.assertEquals("foo-email-subject", options_result["email_subject"])
@@ -171,6 +171,8 @@ class OptionsResolverTestCase(unittest.TestCase):
         logger = mock.MagicMock()
         resolver = optionsresolver.OptionsResolver(logger)
         options_result = resolver.setup_options()
+        print options_result
+        print config_file_options
 
         self.assertEquals("foo-host", options_result["host"])
         self.assertEquals("foo-port", options_result["port"])
@@ -182,10 +184,10 @@ class OptionsResolverTestCase(unittest.TestCase):
         self.assertEquals(20, options_result["conditions"]["foo-queue"]["ready_queue_size"])
         self.assertEquals(30, options_result["conditions"]["foo-queue"]["unack_queue_size"])
         self.assertEquals(40, options_result["conditions"]["foo-queue"]["total_queue_size"])
-        self.assertEquals(50, options_result["conditions"]["foo-queue"]["consumers_connected"])
-        self.assertEquals(51, options_result["conditions"]["foo-queue"]["open_connections"])
-        self.assertEquals(60, options_result["conditions"]["foo-queue"]["nodes_running"])
-        self.assertEquals(70, options_result["conditions"]["foo-queue"]["node_memory_used"])
+        self.assertEquals(50, options_result["default_conditions"]["consumers_connected"])
+        self.assertEquals(51, options_result["default_conditions"]["open_connections"])
+        self.assertEquals(60, options_result["default_conditions"]["nodes_running"])
+        self.assertEquals(70, options_result["default_conditions"]["node_memory_used"])
         self.assertEquals(["foo-email-to"], options_result["email_to"])
         self.assertEquals("foo-email-from", options_result["email_from"])
         self.assertEquals("foo-email-subject", options_result["email_subject"])
@@ -246,10 +248,10 @@ class OptionsResolverTestCase(unittest.TestCase):
         self.assertEquals(20, options_result["conditions"]["foo-queue"]["ready_queue_size"])
         self.assertEquals(30, options_result["conditions"]["foo-queue"]["unack_queue_size"])
         self.assertEquals(40, options_result["conditions"]["foo-queue"]["total_queue_size"])
-        self.assertEquals(50, options_result["conditions"]["foo-queue"]["consumers_connected"])
-        self.assertEquals(51, options_result["conditions"]["foo-queue"]["open_connections"])
-        self.assertEquals(60, options_result["conditions"]["foo-queue"]["nodes_running"])
-        self.assertEquals(70, options_result["conditions"]["foo-queue"]["node_memory_used"])
+        self.assertEquals(50, options_result["default_conditions"]["consumers_connected"])
+        self.assertEquals(51, options_result["default_conditions"]["open_connections"])
+        self.assertEquals(60, options_result["default_conditions"]["nodes_running"])
+        self.assertEquals(70, options_result["default_conditions"]["node_memory_used"])
         self.assertEquals(["foo-email-to"], options_result["email_to"])
         self.assertEquals("foo-email-from", options_result["email_from"])
         self.assertEquals("foo-email-subject", options_result["email_subject"])
@@ -289,17 +291,13 @@ class OptionsResolverTestCase(unittest.TestCase):
         self.assertEquals(20, options_result["conditions"]["foo-queue"]["ready_queue_size"])
         self.assertEquals(30, options_result["conditions"]["foo-queue"]["unack_queue_size"])
         self.assertEquals(40, options_result["conditions"]["foo-queue"]["total_queue_size"])
-        self.assertEquals(50, options_result["conditions"]["foo-queue"]["consumers_connected"])
-        self.assertEquals(51, options_result["conditions"]["foo-queue"]["open_connections"])
-        self.assertEquals(60, options_result["conditions"]["foo-queue"]["nodes_running"])
-        self.assertEquals(70, options_result["conditions"]["foo-queue"]["node_memory_used"])
         self.assertEquals(30, options_result["conditions"]["bar-queue"]["ready_queue_size"])
         self.assertEquals(40, options_result["conditions"]["bar-queue"]["unack_queue_size"])
         self.assertEquals(50, options_result["conditions"]["bar-queue"]["total_queue_size"])
-        self.assertEquals(60, options_result["conditions"]["bar-queue"]["consumers_connected"])
-        self.assertEquals(61, options_result["conditions"]["bar-queue"]["open_connections"])
-        self.assertEquals(70, options_result["conditions"]["bar-queue"]["nodes_running"])
-        self.assertEquals(80, options_result["conditions"]["bar-queue"]["node_memory_used"])
+        self.assertEquals(50, options_result["default_conditions"]["consumers_connected"])
+        self.assertEquals(51, options_result["default_conditions"]["open_connections"])
+        self.assertEquals(60, options_result["default_conditions"]["nodes_running"])
+        self.assertEquals(70, options_result["default_conditions"]["node_memory_used"])
         self.assertEquals(["foo-email-to"], options_result["email_to"])
         self.assertEquals("foo-email-from", options_result["email_from"])
         self.assertEquals("foo-email-subject", options_result["email_subject"])
@@ -363,13 +361,14 @@ class OptionsResolverTestCase(unittest.TestCase):
         self.assertEquals("foo-vhost", options_result["vhost"])
         self.assertEquals(["foo-queue"], options_result["queues"])
         self.assertEquals(10, options_result["check_rate"])
+        print options_result
         self.assertEquals(20, options_result["conditions"]["foo-queue"]["ready_queue_size"])
         self.assertEquals(30, options_result["conditions"]["foo-queue"]["unack_queue_size"])
         self.assertEquals(40, options_result["conditions"]["foo-queue"]["total_queue_size"])
-        self.assertEquals(50, options_result["conditions"]["foo-queue"]["consumers_connected"])
-        self.assertEquals(51, options_result["conditions"]["foo-queue"]["open_connections"])
-        self.assertEquals(60, options_result["conditions"]["foo-queue"]["nodes_running"])
-        self.assertEquals(70, options_result["conditions"]["foo-queue"]["node_memory_used"])
+        self.assertEquals(50, options_result["default_conditions"]["consumers_connected"])
+        self.assertEquals(51, options_result["default_conditions"]["open_connections"])
+        self.assertEquals(60, options_result["default_conditions"]["nodes_running"])
+        self.assertEquals(70, options_result["default_conditions"]["node_memory_used"])
         self.assertIsNone(options_result["email_to"])
         self.assertIsNone(options_result["email_from"])
         self.assertIsNone(options_result["email_subject"])
@@ -479,14 +478,16 @@ class OptionsResolverTestCase(unittest.TestCase):
                 "queues": "foo-queue",
                 "check_rate": "10"
             },
+            "Conditions": {
+                "open_connections": "51",
+                "nodes_running": "60",
+                "node_memory_used": "70",
+                "consumers_connected": "50",
+            },
             "Conditions:foo-queue": {
                 "ready_queue_size": "20",
                 "unack_queue_size": "30",
                 "total_queue_size": "40",
-                "consumers_connected": "50",
-                "open_connections": "51",
-                "nodes_running": "60",
-                "node_memory_used": "70"
             },
             "Email": {
                 "to": "foo-email-to",
@@ -519,23 +520,21 @@ class OptionsResolverTestCase(unittest.TestCase):
                 "queues": "foo-queue,bar-queue",
                 "check_rate": "10"
             },
-            "Conditions:foo-queue": {
-                "ready_queue_size": "20",
-                "unack_queue_size": "30",
-                "total_queue_size": "40",
+            "Conditions": {
                 "consumers_connected": "50",
                 "open_connections": "51",
                 "nodes_running": "60",
                 "node_memory_used": "70"
             },
+            "Conditions:foo-queue": {
+                "ready_queue_size": "20",
+                "unack_queue_size": "30",
+                "total_queue_size": "40",
+            },
             "Conditions:bar-queue": {
                 "ready_queue_size": "30",
                 "unack_queue_size": "40",
                 "total_queue_size": "50",
-                "consumers_connected": "60",
-                "open_connections": "61",
-                "nodes_running": "70",
-                "node_memory_used": "80"
             },
             "Email": {
                 "to": "foo-email-to",

--- a/rabbitmqalert/tests/test_optionsresolver.py
+++ b/rabbitmqalert/tests/test_optionsresolver.py
@@ -171,8 +171,6 @@ class OptionsResolverTestCase(unittest.TestCase):
         logger = mock.MagicMock()
         resolver = optionsresolver.OptionsResolver(logger)
         options_result = resolver.setup_options()
-        print options_result
-        print config_file_options
 
         self.assertEquals("foo-host", options_result["host"])
         self.assertEquals("foo-port", options_result["port"])
@@ -361,7 +359,6 @@ class OptionsResolverTestCase(unittest.TestCase):
         self.assertEquals("foo-vhost", options_result["vhost"])
         self.assertEquals(["foo-queue"], options_result["queues"])
         self.assertEquals(10, options_result["check_rate"])
-        print options_result
         self.assertEquals(20, options_result["conditions"]["foo-queue"]["ready_queue_size"])
         self.assertEquals(30, options_result["conditions"]["foo-queue"]["unack_queue_size"])
         self.assertEquals(40, options_result["conditions"]["foo-queue"]["total_queue_size"])

--- a/rabbitmqalert/tests/test_rabbitmqalert.py
+++ b/rabbitmqalert/tests/test_rabbitmqalert.py
@@ -378,6 +378,15 @@ class RabbitMQAlertTestCase(unittest.TestCase):
             "vhost": "foo",
             "queue": "foo",
             "queues": ["foo"],
+            "default_conditions": {
+                "ready_queue_size": 0,
+                "unack_queue_size": 0,
+                "total_queue_size": 0,
+                "consumers_connected": 1,
+                "open_connections": 1,
+                "nodes_running": 1,
+                "node_memory_used": 1
+            },
             "conditions": {
                 "foo": {
                     "ready_queue_size": 0,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 from os import path
 
 # remember to push a new tag after changing this!
-VERSION = "1.3.3"
+VERSION = "1.4.0"
 
 DIST_CONFIG_PATH = "rabbitmqalert/config"
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 from os import path
 
 # remember to push a new tag after changing this!
-VERSION = "1.3.2"
+VERSION = "1.3.3"
 
 DIST_CONFIG_PATH = "rabbitmqalert/config"
 
@@ -25,6 +25,7 @@ def generate_data_files():
         DATA_FILES.append(("/etc/init.d/", [DIST_CONFIG_PATH + "/service/rabbitmq-alert"]))
 
     return DATA_FILES
+
 
 setup(
     name="rabbitmq-alert",


### PR DESCRIPTION
Consumers connected should be matched per queue.
While nodes_running and open_connections are common for all queues and it's redundant to check them more then once in a loop.