### PR TITLE
Fix arguments parser

### DIFF
--- a/rabbitmqalert/models/argument.py
+++ b/rabbitmqalert/models/argument.py
@@ -76,12 +76,12 @@ class Argument:
     def get_value(self, group, argument):
 
         def foo():
-            # get value from cli arguments
-            yield (self.arguments[argument.dest] if argument.dest in self.arguments else None)
             # get value from configuration file (given or global configuration file)
             yield self.get_value_from_file(self.file, group, argument)
             # get value from the defaults file
             yield self.get_value_from_file(self.defaults, group, argument)
+            # get value from cli arguments
+            yield (self.arguments[argument.dest] if argument.dest in self.arguments else None)
 
         value = None
         try:


### PR DESCRIPTION
If in [Conditions] one of the options is globally set. Then in [Conditions: ...] it is not parsed